### PR TITLE
client/core: OrderBook update notifications races

### DIFF
--- a/client/core/account.go
+++ b/client/core/account.go
@@ -233,7 +233,7 @@ func (c *Core) UpdateCert(host string, cert []byte) error {
 	}
 
 	// Stop reconnect retry for previous dex connection first but leave it in
-	// the map so it remains listed incase we need it in the interim.
+	// the map so it remains listed in case we need it in the interim.
 	if found {
 		dc.connMaster.Disconnect()
 		dc.acct.lock()

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -140,7 +140,9 @@ type dexConnection struct {
 	// actions performed on a particular bookie in that map (such as
 	// preventing applying any order book updates until order book snapshot
 	// is taken by another go-routine, so that it can get a feed on those
-	// changes to keep the original snapshot in sync).
+	// changes to keep the original snapshot in sync; another use case is to
+	// prevent terminating bookie with bookie.closeTimer while it's in the
+	// process of issuing new feed via bookie.newFeed()).
 	booksMtx sync.RWMutex
 	books    map[string]*bookie
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -6,6 +6,7 @@ package core
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
@@ -701,10 +702,10 @@ const (
 
 // BookUpdate is an order book update.
 type BookUpdate struct {
-	Action   string      `json:"action"`
-	Host     string      `json:"host"`
-	MarketID string      `json:"marketID"`
-	Payload  interface{} `json:"payload"`
+	Action   string          `json:"action"`
+	Host     string          `json:"host"`
+	MarketID string          `json:"marketID"`
+	Payload  json.RawMessage `json:"payload"`
 }
 
 type CandlesPayload struct {

--- a/client/orderbook/epochqueue.go
+++ b/client/orderbook/epochqueue.go
@@ -52,7 +52,7 @@ func (eq *EpochQueue) Enqueue(note *msgjson.EpochOrderNote) error {
 	// Ensure the provided epoch order is not already queued.
 	_, ok := eq.orders[oid]
 	if ok {
-		return fmt.Errorf("%s is already queued", oid)
+		return fmt.Errorf("%s is already queued", oid) // should never happen
 	}
 
 	var commitment order.Commitment

--- a/client/orderbook/orderbook.go
+++ b/client/orderbook/orderbook.go
@@ -224,7 +224,7 @@ func (ob *OrderBook) processCachedNotes() error {
 }
 
 // Sync updates a client tracked order book with an order book snapshot. It is
-// an error if the the OrderBook is already synced.
+// an error if the OrderBook is already synced.
 func (ob *OrderBook) Sync(snapshot *msgjson.OrderBook) error {
 	if ob.isSynced() {
 		return fmt.Errorf("order book is already synced")

--- a/client/orderbook/orderbook.go
+++ b/client/orderbook/orderbook.go
@@ -224,7 +224,7 @@ func (ob *OrderBook) processCachedNotes() error {
 }
 
 // Sync updates a client tracked order book with an order book snapshot. It is
-// an error if the OrderBook is already synced.
+// an error if the the OrderBook is already synced.
 func (ob *OrderBook) Sync(snapshot *msgjson.OrderBook) error {
 	if ob.isSynced() {
 		return fmt.Errorf("order book is already synced")

--- a/client/orderbook/orderbook_test.go
+++ b/client/orderbook/orderbook_test.go
@@ -1030,20 +1030,21 @@ func TestValidateMatchProof(t *testing.T) {
 		t.Fatalf("[Enqueue]: unexpected error: %v", err)
 	}
 
-	matchProofNote = msgjson.MatchProofNote{
-		MarketID:  mid,
-		Epoch:     epoch,
-		Preimages: []msgjson.Bytes{n1Pimg[:], n2Pimg[:]},
-		Misses:    []msgjson.Bytes{},
-		CSum:      expectedCSum,
-		Seed:      expectedSeed,
-	}
-
+	// We currently don't support this type of validation, see comments in ValidateMatchProof.
+	//matchProofNote = msgjson.MatchProofNote{
+	//	MarketID:  mid,
+	//	Epoch:     epoch,
+	//	Preimages: []msgjson.Bytes{n1Pimg[:], n2Pimg[:]},
+	//	Misses:    []msgjson.Bytes{},
+	//	CSum:      expectedCSum,
+	//	Seed:      expectedSeed,
+	//}
+	//
 	// Ensure a invalid match proof message (missing a preimage) gets
 	// detected as expected.
-	if err := ob.ValidateMatchProof(matchProofNote); err == nil {
-		t.Fatalf("[ValidateMatchProof (missing a preimage)]: unexpected an error")
-	}
+	//if err := ob.ValidateMatchProof(matchProofNote); err == nil {
+	//	t.Fatalf("[ValidateMatchProof (missing a preimage)]: unexpected an error")
+	//}
 
 	ob = NewOrderBook(tLogger)
 

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -365,7 +365,7 @@ func NewRequest(id uint64, route string, payload interface{}) (*Message, error) 
 	}
 	return &Message{
 		Type:    Request,
-		Payload: json.RawMessage(encoded),
+		Payload: encoded,
 		Route:   route,
 		ID:      id,
 	}, nil
@@ -390,7 +390,7 @@ func NewResponse(id uint64, result interface{}, rpcErr *Error) (*Message, error)
 	}
 	return &Message{
 		Type:    Response,
-		Payload: json.RawMessage(encResp),
+		Payload: encResp,
 		ID:      id,
 	}, nil
 }
@@ -425,7 +425,7 @@ func NewNotification(route string, payload interface{}) (*Message, error) {
 	return &Message{
 		Type:    Notification,
 		Route:   route,
-		Payload: json.RawMessage(encPayload),
+		Payload: encPayload,
 	}, nil
 }
 

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -540,7 +540,7 @@ func (r *BookRouter) Book(mktName string) (*msgjson.OrderBook, error) {
 	return msgOB, nil
 }
 
-// sendBook encodes and sends the the entire order book to the specified client.
+// sendBook encodes and sends the entire order book to the specified client.
 func (r *BookRouter) sendBook(conn comms.Link, book *msgBook, msgID uint64) {
 	msgOB := r.msgOrderBook(book)
 	if msgOB == nil {

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -173,8 +173,8 @@ func (s *subscribers) remove(id uint64) bool {
 
 // nextSeq gets the next sequence number by incrementing the counter. This
 // should be used when the book and orders are modified. Currently this applies
-// to the routes: book_order, unbook_order, update_remaining, and epoch_order,
-// plus suspend if the book is also being purged (persist=false).
+// to the routes: "book_order", "unbook_order", "update_remaining", "epoch_order",
+// and "suspension" if the book is also being purged (persist=false).
 func (s *subscribers) nextSeq() uint64 {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -698,7 +698,7 @@ func (m *Market) OrderFeed() <-chan *updateSignal {
 // FeedDone informs the market that the caller is finished receiving from the
 // given channel, which should have been obtained from OrderFeed. If the channel
 // was a registered order feed channel from OrderFeed, it is closed and removed
-// so that no further signals will be send on the channel.
+// so that no further signals will be sent on the channel.
 func (m *Market) FeedDone(feed <-chan *updateSignal) bool {
 	m.orderFeedMtx.Lock()
 	defer m.orderFeedMtx.Unlock()


### PR DESCRIPTION
This PR supersedes https://github.com/decred/dcrdex/pull/2203.

Targeting 2 separate things:
- 1st commit is mostly about applying suggestions from https://github.com/decred/dcrdex/issues/2188 (passing immutable data over `chan` when possible)
- 2nd commit is about `dc.booksMtx`, clarifying a lot of non-trivial stuff around it and handling sever **subscribe/resubscribe/suspend** flow such that server order book is observed in consistent state all the time by `dexc` client (and also `feed` receivers that subscribe to `dexc` order book feeds, which is just as important); that means it should fix order book notifications being dropped occasionally
- 3rd, ... commits are just minor clarifications and will be squashed into 2nd commit eventually