### PR TITLE
client/core: monotonic OrderBook state updates

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -9502,9 +9502,10 @@ func TestPreOrder(t *testing.T) {
 	var baseFeeRate uint64 = 5
 	var quoteFeeRate uint64 = 10
 
+	const seedSeq = 1
 	err := book.Sync(&msgjson.OrderBook{
 		MarketID:     tDcrBtcMktName,
-		Seq:          1,
+		Seq:          seedSeq,
 		Epoch:        1,
 		Orders:       []*msgjson.BookOrderNote{sellNote, &buyNote},
 		BaseFeeRate:  baseFeeRate,
@@ -9580,10 +9581,12 @@ func TestPreOrder(t *testing.T) {
 
 	// Market orders have to have a market to make estimates.
 	book.Unbook(&msgjson.UnbookOrderNote{
+		Seq:      seedSeq + 1,
 		MarketID: tDcrBtcMktName,
 		OrderID:  sellNote.OrderID,
 	})
 	book.Unbook(&msgjson.UnbookOrderNote{
+		Seq:      seedSeq + 2,
 		MarketID: tDcrBtcMktName,
 		OrderID:  buyNote.OrderID,
 	})

--- a/client/orderbook/epochqueue_test.go
+++ b/client/orderbook/epochqueue_test.go
@@ -16,11 +16,12 @@ import (
 
 var tLogger = dex.NewLogger("TBOOK", dex.LevelTrace, os.Stdout)
 
-func makeEpochOrderNote(mid string, oid order.OrderID, side uint8, rate uint64, qty uint64, commitment order.Commitment, epoch uint64) *msgjson.EpochOrderNote {
+func makeEpochOrderNote(seq uint64, mid string, oid order.OrderID, side uint8, rate uint64, qty uint64, commitment order.Commitment, epoch uint64) *msgjson.EpochOrderNote {
 	return &msgjson.EpochOrderNote{
 		Commit: commitment[:],
 		BookOrderNote: msgjson.BookOrderNote{
 			OrderNote: msgjson.OrderNote{
+				Seq:      seq,
 				MarketID: mid,
 				OrderID:  oid[:],
 			},
@@ -69,21 +70,21 @@ func TestEpochQueue(t *testing.T) {
 	copy(n1Pimg[:], n1PimgB)
 	n1Commitment := n1Pimg.Commit() // aba75140b1f6edf26955a97e1b09d7b17abdc9c0b099fc73d9729501652fbf66
 	n1OrderID := [32]byte{'a'}
-	n1 := makeEpochOrderNote(mid, n1OrderID, msgjson.BuyOrderNum, 1, 2, n1Commitment, epoch)
+	n1 := makeEpochOrderNote(1, mid, n1OrderID, msgjson.BuyOrderNum, 1, 2, n1Commitment, epoch)
 
 	n2PimgB, _ := hex.DecodeString("8e6c140071db1eb2f7a18194f1a045a94c078835c75dff2f3e836180baad9e95")
 	var n2Pimg order.Preimage
 	copy(n2Pimg[:], n2PimgB)
 	n2Commitment := n2Pimg.Commit() // 0f4bc030d392cef3f44d0781870ab7fcb78a0cda36c73e50b88c741b4f851600
 	n2OrderID := [32]byte{'b'}
-	n2 := makeEpochOrderNote(mid, n2OrderID, msgjson.BuyOrderNum, 1, 2, n2Commitment, epoch)
+	n2 := makeEpochOrderNote(2, mid, n2OrderID, msgjson.BuyOrderNum, 1, 2, n2Commitment, epoch)
 
 	n3PimgB, _ := hex.DecodeString("e1f796fa0fc16ba7bb90be2a33e87c3d60ab628471a420834383661801bb0bfd")
 	var n3Pimg order.Preimage
 	copy(n3Pimg[:], n3PimgB)
 	n3Commitment := n3Pimg.Commit() // aba75140b1f6edf26955a97e1b09d7b17abdc9c0b099fc73d9729501652fbf66
 	n3OrderID := [32]byte{'c'}
-	n3 := makeEpochOrderNote(mid, n3OrderID, msgjson.BuyOrderNum, 1, 2, n3Commitment, epoch)
+	n3 := makeEpochOrderNote(3, mid, n3OrderID, msgjson.BuyOrderNum, 1, 2, n3Commitment, epoch)
 
 	// This csum matches the server-side tests.
 	wantCSum, _ := hex.DecodeString("8c743c3225b89ffbb50b5d766d3e078cd8e2658fa8cb6e543c4101e1d59a8e8e")
@@ -257,7 +258,7 @@ func benchmarkGenerateMatchProof(c int, b *testing.B) {
 	preimages := make([]order.Preimage, 0, c)
 	for i := range notes {
 		pi := randPreimage()
-		notes[i] = makeEpochOrderNote("mkt", randOrderID(),
+		notes[i] = makeEpochOrderNote(uint64(i), "mkt", randOrderID(),
 			msgjson.BuyOrderNum, 1, 2, blake256.Sum256(pi[:]), 10)
 		preimages = append(preimages, pi)
 	}

--- a/client/orderbook/orderbook_test.go
+++ b/client/orderbook/orderbook_test.go
@@ -3,6 +3,7 @@ package orderbook
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"decred.org/dcrdex/dex/msgjson"
@@ -241,7 +242,7 @@ func TestOrderBookSync(t *testing.T) {
 			}
 
 			if len(tc.orderBook.sells.bins) != len(tc.expected.sells.bins) {
-				t.Fatalf("[OrderBook.Sync] #%d: expected buys book side "+
+				t.Fatalf("[OrderBook.Sync] #%d: expected sells book side "+
 					"size of %d, got %d", idx+1, len(tc.expected.sells.bins),
 					len(tc.orderBook.sells.bins))
 			}
@@ -289,33 +290,31 @@ func TestOrderBookBook(t *testing.T) {
 			),
 			wantErr: false,
 		},
-		// May want to re-implement strict sequence checking. Might use these tests
-		// again.
-		// {
-		// 	label: "Book buy order with outdated sequence value",
-		// 	orderBook: makeOrderBook(
-		// 		2,
-		// 		"ob",
-		// 		[]*Order{
-		// 			makeOrder([32]byte{'b'}, msgjson.BuyOrderNum, 10, 1, 2),
-		// 			makeOrder([32]byte{'c'}, msgjson.BuyOrderNum, 10, 2, 5),
-		// 		},
-		// 		make([]*cachedOrderNote, 0),
-		// 		true,
-		// 	),
-		// 	note: makeBookOrderNote(0, "ob", [32]byte{'a'}, msgjson.BuyOrderNum, 2, 3, 1),
-		// 	expected: makeOrderBook(
-		// 		2,
-		// 		"ob",
-		// 		[]*Order{
-		// 			makeOrder([32]byte{'b'}, msgjson.BuyOrderNum, 10, 1, 2),
-		// 			makeOrder([32]byte{'c'}, msgjson.BuyOrderNum, 10, 2, 5),
-		// 		},
-		// 		make([]*cachedOrderNote, 0),
-		// 		true,
-		// 	),
-		// 	wantErr: false,
-		// },
+		{
+			label: "Book buy order with outdated sequence value",
+			orderBook: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.BuyOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.BuyOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			note: makeBookOrderNote(0, "ob", [32]byte{'a'}, msgjson.BuyOrderNum, 2, 3, 1),
+			expected: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.BuyOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.BuyOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			wantErr: false,
+		},
 		{
 			label: "Book buy order to unsynced order book",
 			orderBook: makeOrderBook(
@@ -360,24 +359,56 @@ func TestOrderBookBook(t *testing.T) {
 			expected: nil,
 			wantErr:  true,
 		},
-		// May want to re-implement strict sequence checking. Might use these tests
-		// again.
-		// {
-		// 	label: "Book sell order to synced order book with future sequence value",
-		// 	orderBook: makeOrderBook(
-		// 		2,
-		// 		"ob",
-		// 		[]*Order{
-		// 			makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
-		// 			makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
-		// 		},
-		// 		make([]*cachedOrderNote, 0),
-		// 		true,
-		// 	),
-		// 	note:     makeBookOrderNote(5, "ob", [32]byte{'d'}, msgjson.SellOrderNum, 5, 3, 10),
-		// 	expected: nil,
-		// 	wantErr:  true,
-		// },
+		{
+			label: "Book sell order to synced order book with past sequence value",
+			orderBook: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			note: makeBookOrderNote(2, "ob", [32]byte{'d'}, msgjson.SellOrderNum, 5, 3, 10),
+			expected: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			wantErr: false,
+		},
+		{
+			label: "Book sell order to synced order book with future sequence value",
+			orderBook: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			note: makeBookOrderNote(5, "ob", [32]byte{'d'}, msgjson.SellOrderNum, 5, 3, 10),
+			expected: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			wantErr: false,
+		},
 	}
 
 	for idx, tc := range tests {
@@ -410,7 +441,7 @@ func TestOrderBookBook(t *testing.T) {
 			}
 
 			if len(tc.orderBook.sells.bins) != len(tc.expected.sells.bins) {
-				t.Fatalf("[OrderBook.Book] #%d: expected buys book side "+
+				t.Fatalf("[OrderBook.Book] #%d: expected sells book side "+
 					"size of %d, got %d", idx+1, len(tc.expected.sells.bins),
 					len(tc.orderBook.sells.bins))
 			}
@@ -425,13 +456,14 @@ func TestOrderBookBook(t *testing.T) {
 }
 
 func TestOrderBookUpdateRemaining(t *testing.T) {
+	const seedSeq = 1
 	var qty uint64 = 10
 	var remaining uint64 = 5
 	mid := "abc_xyz"
 	oid := order.OrderID{0x01}
 
 	book := makeOrderBook(
-		1,
+		seedSeq,
 		mid,
 		[]*Order{
 			makeOrder(oid, msgjson.SellOrderNum, qty, 1, 2),
@@ -444,6 +476,7 @@ func TestOrderBookUpdateRemaining(t *testing.T) {
 		OrderNote: msgjson.OrderNote{
 			OrderID:  oid[:],
 			MarketID: mid,
+			Seq:      seedSeq + 1,
 		},
 		Remaining: remaining,
 	}
@@ -460,17 +493,37 @@ func TestOrderBookUpdateRemaining(t *testing.T) {
 	// Unknown order
 	wrongID := order.OrderID{0x02}
 	urNote.OrderID = wrongID[:]
+	urNote.Seq++
 	err = book.UpdateRemaining(urNote)
 	if err == nil {
 		t.Fatalf("no error updating remaining qty for unknown order")
 	}
+	urNote.OrderID = oid[:] // cleanup
 
 	// Bad order ID
 	urNote.OrderID = []byte{0x03}
+	urNote.Seq++
 	err = book.UpdateRemaining(urNote)
 	if err == nil {
+		fmt.Println(err)
 		t.Fatalf("no error updating remaining qty for invalid order ID")
 	}
+	urNote.OrderID = oid[:] // cleanup
+
+	// Bad order Seq (from past)
+	// Skipping increment urNote.Seq here.
+	err = book.UpdateRemaining(urNote)
+	if err != nil {
+		t.Fatalf("shoudln't error about note from recent past") // we just log error
+	}
+
+	// Bad order Seq (from future)
+	urNote.Seq += 2
+	err = book.UpdateRemaining(urNote)
+	if err != nil {
+		t.Fatalf("shoudln't error about note from future") // we just log error
+	}
+	urNote.Seq -= 2 // cleanup
 }
 
 func TestOrderBookUnbook(t *testing.T) {
@@ -505,33 +558,31 @@ func TestOrderBookUnbook(t *testing.T) {
 			),
 			wantErr: false,
 		},
-		// May want to re-implement strict sequence checking. Might use these tests
-		// again.
-		// {
-		// 	label: "Unbook sell order with outdated sequence value",
-		// 	orderBook: makeOrderBook(
-		// 		2,
-		// 		"ob",
-		// 		[]*Order{
-		// 			makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
-		// 			makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
-		// 		},
-		// 		make([]*cachedOrderNote, 0),
-		// 		true,
-		// 	),
-		// 	note: makeUnbookOrderNote(0, "ob", [32]byte{'a'}),
-		// 	expected: makeOrderBook(
-		// 		2,
-		// 		"ob",
-		// 		[]*Order{
-		// 			makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
-		// 			makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
-		// 		},
-		// 		make([]*cachedOrderNote, 0),
-		// 		true,
-		// 	),
-		// 	wantErr: false,
-		// },
+		{
+			label: "Unbook sell order with outdated sequence value",
+			orderBook: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			note: makeUnbookOrderNote(0, "ob", [32]byte{'c'}),
+			expected: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			wantErr: false,
+		},
 		{
 			label: "Unbook sell order with unsynced order book",
 			orderBook: makeOrderBook(
@@ -544,7 +595,7 @@ func TestOrderBookUnbook(t *testing.T) {
 				make([]*cachedOrderNote, 0),
 				false,
 			),
-			note: makeUnbookOrderNote(3, "ob", [32]byte{'a'}),
+			note: makeUnbookOrderNote(3, "ob", [32]byte{'c'}),
 			expected: makeOrderBook(
 				2,
 				"ob",
@@ -572,9 +623,34 @@ func TestOrderBookUnbook(t *testing.T) {
 				make([]*cachedOrderNote, 0),
 				true,
 			),
-			note:     makeUnbookOrderNote(3, "oc", [32]byte{'a'}),
+			note:     makeUnbookOrderNote(3, "oc", [32]byte{'c'}),
 			expected: nil,
 			wantErr:  true,
+		},
+		{
+			label: "Unbook sell order with past sequence value",
+			orderBook: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			note: makeUnbookOrderNote(2, "ob", [32]byte{'c'}),
+			expected: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			wantErr: false,
 		},
 		{
 			label: "Unbook sell order with future sequence value",
@@ -588,9 +664,18 @@ func TestOrderBookUnbook(t *testing.T) {
 				make([]*cachedOrderNote, 0),
 				true,
 			),
-			note:     makeUnbookOrderNote(5, "ob", [32]byte{'d'}),
-			expected: nil,
-			wantErr:  true,
+			note: makeUnbookOrderNote(5, "ob", [32]byte{'c'}),
+			expected: makeOrderBook(
+				2,
+				"ob",
+				[]*Order{
+					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+				},
+				make([]*cachedOrderNote, 0),
+				true,
+			),
+			wantErr: false,
 		},
 	}
 
@@ -624,7 +709,7 @@ func TestOrderBookUnbook(t *testing.T) {
 			}
 
 			if len(tc.orderBook.sells.bins) != len(tc.expected.sells.bins) {
-				t.Fatalf("[OrderBook.Book] #%d: expected buys book side "+
+				t.Fatalf("[OrderBook.Book] #%d: expected sells book side "+
 					"size of %d, got %d", idx+1, len(tc.expected.sells.bins),
 					len(tc.orderBook.sells.bins))
 			}
@@ -924,17 +1009,17 @@ func TestValidateMatchProof(t *testing.T) {
 	n1Pimg := [32]byte{'1'}
 	n1Commitment := makeCommitment(n1Pimg)
 	n1OrderID := [32]byte{'a'}
-	n1 := makeEpochOrderNote(mid, n1OrderID, msgjson.BuyOrderNum, 1, 2, n1Commitment, epoch)
+	n1 := makeEpochOrderNote(1, mid, n1OrderID, msgjson.BuyOrderNum, 1, 2, n1Commitment, epoch)
 
 	n2Pimg := [32]byte{'2'}
 	n2Commitment := makeCommitment(n2Pimg)
 	n2OrderID := [32]byte{'b'}
-	n2 := makeEpochOrderNote(mid, n2OrderID, msgjson.BuyOrderNum, 1, 2, n2Commitment, epoch)
+	n2 := makeEpochOrderNote(2, mid, n2OrderID, msgjson.BuyOrderNum, 1, 2, n2Commitment, epoch)
 
 	n3Pimg := [32]byte{'3'}
 	n3Commitment := makeCommitment(n3Pimg)
 	n3OrderID := [32]byte{'c'}
-	n3 := makeEpochOrderNote(mid, n3OrderID, msgjson.BuyOrderNum, 1, 2, n3Commitment, epoch)
+	n3 := makeEpochOrderNote(3, mid, n3OrderID, msgjson.BuyOrderNum, 1, 2, n3Commitment, epoch)
 
 	err := ob.Enqueue(n1)
 	if err != nil {


### PR DESCRIPTION
Should prevent: 
- [applying notifications from the past](https://github.com/norwnd/dcrdex/pull/1#issuecomment-1459776804), these are quite expected but shouldn't happen often (if ever) in practice
- applying notifications from the future, as far as I can tell this is a bug (it should be resolved by https://github.com/norwnd/dcrdex/pull/1 + https://github.com/norwnd/dcrdex/pull/2) and we shouldn't have those ever