### PR TITLE
client/asset/eth: remove ineffectual brickedFailCount param

### DIFF
--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -50,7 +50,6 @@ const (
 	receiptCacheExpiration       = time.Hour
 	unconfirmedReceiptExpiration = time.Minute
 	tipCapSuggestionExpiration   = time.Hour
-	brickedFailCount             = 100
 	providerDelimiter            = " "
 	defaultRequestTimeout        = time.Second * 10
 )
@@ -151,7 +150,7 @@ func (p *provider) setFailed() {
 func (p *provider) failed() bool {
 	p.tip.Lock()
 	defer p.tip.Unlock()
-	return p.tip.failCount > brickedFailCount || time.Since(p.tip.failStamp) < failQuarantine
+	return time.Since(p.tip.failStamp) < failQuarantine
 }
 
 // bestHeader get the best known header from the provider, cached if available,


### PR DESCRIPTION
When testing I discovered this `brickedFailCount` doesn't really have any effect because `tip.failCount` gets reset to `0` before ever reaching it, and `failQuarantine` is probably does the job on its own anyway.