### PR TITLE
server: setup with PG in Docker

### DIFF
--- a/server/cmd/dcrdex/sample-dcrdex.conf
+++ b/server/cmd/dcrdex/sample-dcrdex.conf
@@ -94,7 +94,7 @@
 ; PostgreSQL DB password.
 ; Can be omitted when UNIX socket is used.
 ; HINT: check pg_hba.conf for postgresql authentication settings.
-; pgpass=
+pgpass=dexpass
 
 ; PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql).
 ; Default value is 127.0.0.1:5432
@@ -182,3 +182,4 @@
 ; Disable the HTTP data API.
 ; Default is false.
 ; nodata=true
+

--- a/server/cmd/dcrdex/sample-markets.json
+++ b/server/cmd/dcrdex/sample-markets.json
@@ -1,81 +1,46 @@
 {
     "markets": [
         {
-            "base": "DCR_mainnet",
-            "quote": "BTC_mainnet",
+            "base": "DCR_testnet",
+            "quote": "ETH_testnet",
             "lotSize": 100000000,
-            "rateStep": 100000,
-            "epochDuration": 10000,
+            "rateStep": 1000,
+            "epochDuration": 6000,
             "marketBuyBuffer": 1.25
         },
         {
-            "base": "BTC_testnet",
-            "quote": "LTC_testnet",
-            "lotSize": 100000,
+            "base": "DCR_testnet",
+            "quote": "USDC_ETH_testnet",
+            "lotSize": 100000000,
             "rateStep": 1000000,
             "epochDuration": 6000,
             "marketBuyBuffer": 1.25
         }
     ],
     "assets": {
-        "DCR_mainnet": {
-            "bip44symbol": "dcr",
-            "network": "mainnet",
-            "maxFeeRate": 10,
-            "swapConf": 4,
-            "configPath": "/home/dcrd/.dcrd/dcrd.conf",
-            "regConfs": 2,
-            "regFee": 10000000,
-            "regXPub": "xpubdecredonlyadsf",
-            "bondAmt": 100000000,
-            "bondConfs": 1
-        },
         "DCR_testnet": {
             "bip44symbol": "dcr",
             "network": "testnet",
             "maxFeeRate": 10,
             "swapConf": 1,
-            "configPath": "/home/dcrd/.dcrd/dcrd.conf",
-            "regFee": 10000000,
-            "regXPub": "tpubdecredonlyadsf",
-            "bondAmt": 100000000,
+            "configPath": "/Users/norwnd/Library/Application Support/Dcrd/dcrd.conf",
+            "regFee": 10000,
+            "regXPub": "tpubVpZ9t5AHWHeVpT5V81jST5z32gwsCNGDCRmZZeN5ki6yZYDpxfo7XPmFyQDQVcTJM8x5K2dHAEvAMBSbaLi9QhbA5X5QAYopFMFZMm5B5mh",
+            "bondAmt": 100000,
             "bondConfs": 1
-        },
-        "BTC_mainnet": {
-            "bip44symbol": "btc",
-            "network": "mainnet",
-            "maxFeeRate": 100,
-            "swapConf": 3,
-            "regConfs": 2,
-            "regFee": 500000,
-            "regXPub": "xpubbitcoinonlyasdf"
-        },
-        "BTC_testnet": {
-            "bip44symbol": "btc",
-            "network": "testnet",
-            "maxFeeRate": 100,
-            "swapConf": 1
-        },
-        "LTC_mainnet": {
-            "bip44symbol": "ltc",
-            "network": "mainnet",
-            "maxFeeRate": 20,
-            "swapConf": 6
-        },
-        "LTC_testnet": {
-            "bip44symbol": "ltc",
-            "network": "testnet",
-            "maxFeeRate": 20,
-            "swapConf": 6
         },
         "ETH_testnet": {
             "bip44symbol": "eth",
             "network": "testnet",
-            "lotSize": 1000000000,
-            "rateStep": 1000000000,
             "maxFeeRate": 200,
             "swapConf": 12,
-            "configPath": "/home/.ethereum/dex.conf"
+            "configPath": "/Users/norwnd/Library/Application Support/Dcrdex/ethereum.conf"
+        },
+        "USDC_ETH_testnet": {
+            "bip44symbol": "usdc.eth",
+            "network": "testnet",
+            "maxFeeRate": 200,
+            "swapConf": 12
         }
     }
 }

--- a/server/docker/deps-compose.yml
+++ b/server/docker/deps-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  postgres:
+    container_name: "postgres"
+    hostname: postgres
+    image: postgres:12-alpine
+    ports:
+      - "5432:5432"
+    volumes:
+      - server_db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: dcrdex
+      POSTGRES_PASSWORD: dexpass
+      POSTGRES_DB: dcrdex_testnet
+volumes:
+  server_db:
+    driver: local


### PR DESCRIPTION
This describes how to set up DEX **server** on **testnet** with Postgres in Docker (managed by docker-compose). Just notes for myself.

Install Decred cli suite: https://docs.decred.org/wallets/cli/cli-installation/

Set up dcrwallet and copy rpc.cert into its cfg dir from dcrd cfg dir: https://docs.decred.org/wallets/cli/dcrwallet-setup/
Then configure legacy account public key: https://github.com/decred/dcrdex/wiki/Server-Installation#generate-a-dcrwallet-account-public-key (won't be using it, just for bypassing some legacy validation)

Set up DEX server configuration files (in `.../Dcrdex` cfg dir), use sample config files from this PR to get some working configuration (search by `sample-`): 
- `ethereum.conf` that contains a bunch of Providers:
```
https://rpc.ankr.com/eth_goerli
https://goerli.infura.io/v3/461b0a1394a9420fab769fa4994de393
```
- `markets.json`, it will also require paths to **dcrd** (in `.../Dcrdex` cfg dir) and `ethereum.conf` config
- `dcrdex.conf` (set `pgpass=dexpass` https://github.com/decred/dcrdex/wiki/Server-Installation#generate-a-dcrwallet-account-public-key)

Run Postgres in Docker (it also will create `dcrdex` user and `dcrdex_testnet` DB):
```
make server_deps_up
```
Note, it will run with volume attached and managed by Docker (you can see it via `docker volume ls | grep server_db`) to persist server data between Postgres container restarts. Tip: use https://github.com/sosedoff/pgweb for easy access to DB data.

Run and sync (might take several hours) dcrd:
```
decred/dcrd --testnet --txindex
```

Build and run DEX server:
```
make server_build
make server_run
```

Use printed out URL to connect your `dexc` to this server:
```
127.0.0.1:7232
```
and `rpc.cert` from `.../Dcrdex` cfg dir.