### PR TITLE
arbitrum: PoC testing (with swaps)

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -39,7 +39,6 @@ import (
 	ethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/tyler-smith/go-bip39"
 )
@@ -65,9 +64,9 @@ func init() {
 const (
 	// BipID is the BIP-0044 asset ID.
 	BipID               = 60
-	defaultGasFee       = 82  // gwei
-	defaultGasFeeLimit  = 200 // gwei
-	defaultSendGasLimit = 21_000
+	defaultGasFee       = 82      // gwei
+	defaultGasFeeLimit  = 2       // gwei
+	defaultSendGasLimit = 210_000 // sending ETH requires > than 21000
 
 	walletTypeGeth = "geth"
 	walletTypeRPC  = "rpc"
@@ -158,8 +157,9 @@ var (
 
 	chainIDs = map[dex.Network]int64{
 		dex.Mainnet: 1,
-		dex.Testnet: 5,  // Görli
-		dex.Simnet:  42, // see dex/testing/eth/harness.sh
+		//dex.Testnet: 5,  // Görli
+		dex.Testnet: 421613, // Arbitrum Görli
+		dex.Simnet:  42,     // see dex/testing/eth/harness.sh
 	}
 
 	// unlimitedAllowance is the maximum supported allowance for an erc20
@@ -182,17 +182,20 @@ var (
 	// perTxGasLimit is the most gas we can use on a transaction. It is the
 	// lower of either the per tx or per block gas limit.
 	perTxGasLimit = func() uint64 {
+		// Current value as reported by https://goerli.arbiscan.io/blocks.
+		const arbBlockLimit uint64 = 1_125_899_906_842_624
 		// blockGasLimit is the amount of gas we can use in one transaction
 		// according to the block gas limit.
-		blockGasLimit := ethconfig.Defaults.Miner.GasCeil / maxProportionOfBlockGasLimitToUse
+		blockGasLimit := arbBlockLimit / maxProportionOfBlockGasLimitToUse
 
-		// txGasLimit is the amount of gas we can use in one transaction
-		// according to the default transaction gas fee limit.
-		txGasLimit := uint64(maxTxFeeGwei / defaultGasFeeLimit)
-
-		if blockGasLimit > txGasLimit {
-			return txGasLimit
-		}
+		// TODO: check, not sure whether there is a per-txn limit
+		//// txGasLimit is the amount of gas we can use in one transaction
+		//// according to the default transaction gas fee limit.
+		//txGasLimit := uint64(maxTxFeeGwei / defaultGasFeeLimit)
+		//
+		//if blockGasLimit > txGasLimit {
+		//	return txGasLimit
+		//}
 		return blockGasLimit
 	}()
 )

--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -1444,8 +1444,9 @@ func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log dex.Log
 		mainnetTxHash    = common.HexToHash("0xea1a717af9fad5702f189d6f760bb9a5d6861b4ee915976fe7732c0c95cd8a0e")
 		mainnetBlockHash = common.HexToHash("0x44ebd6f66b4fd546bccdd700869f6a433ef9a47e296a594fa474228f86eeb353")
 
-		testnetAddr      = common.HexToAddress("0x8879F72728C5eaf5fB3C55e6C3245e97601FBa32")
-		testnetUSDC      = common.HexToAddress("0x07865c6E87B9F70255377e024ace6630C1Eaa37F")
+		testnetAddr = common.HexToAddress("0x8879F72728C5eaf5fB3C55e6C3245e97601FBa32")
+		//testnetUSDC      = common.HexToAddress("0x07865c6E87B9F70255377e024ace6630C1Eaa37F")
+		testnetUSDC      = common.HexToAddress("0x8fb1e3fc51f3b789ded7557e680551d93ea9d892")
 		testnetTxHash    = common.HexToHash("0x4e1d455f7eac7e3a5f7c1e0989b637002755eaee3a262f90b0f3aef1f1c4dcf0")
 		testnetBlockHash = common.HexToHash("0x8896021c2666303a85b7e4a6a6f2b075bc705d4e793bf374cd44b83bca23ef9a")
 

--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -46,17 +46,19 @@ var (
 		0: {
 			dex.Mainnet: common.HexToAddress("0x8C17e4968B6903E1601be82Ca989c5B5E2c7b400"),
 			dex.Simnet:  common.HexToAddress("0x2f68e723b8989ba1c6a9f03e42f33cb7dc9d606f"),
-			dex.Testnet: common.HexToAddress("0x198463496037754564e9bea5418Bf4117Db0520C"),
+			//dex.Testnet: common.HexToAddress("0x198463496037754564e9bea5418Bf4117Db0520C"),
+			dex.Testnet: common.HexToAddress("0x37E27F6553F9c45e736c60939f96834ea0006be1"), // Arbitrum ETH swap contract
 		},
 	}
 )
 
+// TODO - 10_000_000 below denotes unknown, needs further testing/investigation.
 var v0Gases = &Gases{
-	Swap:      174500, // 134,500 actual -- https://goerli.etherscan.io/tx/0xa17b6edeaf79791b5fc9232dc05a56d43f3a67845f3248e763b77162fae9b181, verified on mainnet
-	SwapAdd:   146400, // 112,600 actual (247,100 for 2) -- https://goerli.etherscan.io/tx/0xa4fc65b8001bf8c44f1079b3d97adf42eb1097658e360b9033596253b0cbbd04, verified on mainnet
-	Redeem:    78600,  // 60,456 actual -- https://goerli.etherscan.io/tx/0x5b22c48052df4a8ecd03a31b62e5015e6afe18c9ffb05e6cdd77396dfc3ca917, verified on mainnet
-	RedeemAdd: 41000,  // 31,672 actual (92,083 for 2, 123,724 for 3) -- https://goerli.etherscan.io/tx/0xae424cc9b0d43bf934112245cb74ab9eca9c2611eabcd6257b6ec258b071c1e6, https://goerli.etherscan.io/tx/0x7ba7cb945da108d39a5a0ac580d4841c4017a32cd0e244f26845c6ed501d2475, verified on mainnet
-	Refund:    57000,  // 43,014 actual -- https://goerli.etherscan.io/tx/0x586ed4cb7dab043f98d4cc08930d9eb291b0052d140d949b20232ceb6ad15f25
+	Swap:      4_500_000,  // 3_320_448 actual -- https://goerli.arbiscan.io/tx/0xed854a676b3e29aee4fdfbdcfcb80a46d97a665b9d8a03822bd34e00f8351e32
+	SwapAdd:   10_000_000, // 112,600 actual (247,100 for 2) -- https://goerli.etherscan.io/tx/0xa4fc65b8001bf8c44f1079b3d97adf42eb1097658e360b9033596253b0cbbd04, verified on mainnet
+	Redeem:    4_500_000,  // 3,159,648 actual -- https://goerli.arbiscan.io/tx/0x04920452f12468ac398028b61502def2d2c173a504c9001a101b38da94d05ab5
+	RedeemAdd: 10_000_000, // 31,672 actual (92,083 for 2, 123,724 for 3) -- https://goerli.etherscan.io/tx/0xae424cc9b0d43bf934112245cb74ab9eca9c2611eabcd6257b6ec258b071c1e6, https://goerli.etherscan.io/tx/0x7ba7cb945da108d39a5a0ac580d4841c4017a32cd0e244f26845c6ed501d2475, verified on mainnet
+	Refund:    10_000_000, // 43,014 actual -- https://goerli.etherscan.io/tx/0x586ed4cb7dab043f98d4cc08930d9eb291b0052d140d949b20232ceb6ad15f25
 }
 
 // LoadGenesisFile loads a Genesis config from a json file.

--- a/dex/networks/eth/tokens.go
+++ b/dex/networks/eth/tokens.go
@@ -179,10 +179,13 @@ var Tokens = map[uint32]*Token{
 				},
 			},
 			dex.Testnet: {
-				Address: common.HexToAddress("0x07865c6e87b9f70255377e024ace6630c1eaa37f"),
+				//Address: common.HexToAddress("0x07865c6e87b9f70255377e024ace6630c1eaa37f"),
+				Address: common.HexToAddress("0x8fb1e3fc51f3b789ded7557e680551d93ea9d892"), // Arbitrum USDC
 				SwapContracts: map[uint32]*SwapContract{
 					0: {
-						Address: common.HexToAddress("0xA7Af47DB3296206eA543A82ffBF7Fc312698E6C9"),
+						//Address: common.HexToAddress("0xA7Af47DB3296206eA543A82ffBF7Fc312698E6C9"),
+						Address: common.HexToAddress("0xdea876D65945ea9D7Cf4213be307EED2e469e27F"), // Arbitrum USDC swap contract
+						// TODO - 10_000_000 below denotes unknown, needs further testing/investigation.
 						Gas: Gases{
 							// Results from client's GetGasEstimates.
 							//
@@ -215,13 +218,13 @@ var Tokens = map[uint32]*Token{
 							//   [65500 48400 48400 48400 48400]
 							//
 							// Then buffered by about 30%...
-							Swap:      242_000, // actual ~187,880 -- https://goerli.etherscan.io/tx/0x352baccafa96bb09d5c118f8dcce26e34267beb8bcda9c026f8d5353abea50fd, verified on mainnet at 188,013 gas
-							SwapAdd:   146_400, // actual ~112,639 (300,519 for 2) -- https://goerli.etherscan.io/tx/0x97f9a1ed69883a6e701f37883ef74d79a709e0edfc4a45987fa659700663f40e
-							Redeem:    109_000, // actual ~83,850 (initial receive, subsequent ~79,012) -- https://goerli.etherscan.io/tx/0x96f007036b01eb2e44615dc67d3e99748bc133496187348b2af26834f46bfdc8, verified on mainnet at 79,113 gas for subsequent
-							RedeemAdd: 31_600,  // actual ~31,641 (110,653 for 2) -- https://goerli.etherscan.io/tx/0xcf717512796868273ed93c37fa139973c9b8305a736c4a3b50ac9f35ae747f99
-							Refund:    77_000,  // actual ~59,152 -- https://goerli.etherscan.io/tx/0xc5692ad0e6d86b721af75ff3b4b7c2e17d939918db030ebf5444ccf840c7a90b
-							Approve:   78_400,  // actual ~60,190 (initial) -- https://goerli.etherscan.io/tx/0xd695fd174dede7bb798488ead7fed5ef33bcd79932b0fa35db0d17c84c97a8a1, verified on mainnet at 60,311
-							Transfer:  85_100,  // actual ~65,524 (initial receive, subsequent 48,424)
+							Swap:      8_500_000,  // actual ~5,941,395 -- https://goerli.arbiscan.io/tx/0xc9a37e9c9cf2931f0afc6851fdbb5b45a2d12a1e60ece7c832990586a882133a
+							SwapAdd:   10_000_000, // actual ~112,639 (300,519 for 2) -- https://goerli.etherscan.io/tx/0x97f9a1ed69883a6e701f37883ef74d79a709e0edfc4a45987fa659700663f40e
+							Redeem:    6_000_000,  // actual ~4,643,285 -- https://goerli.arbiscan.io/tx/0xe2718ff2bd05352bd585f15c5d8428bf93bfc522c067d54791c51b54205d3eca
+							RedeemAdd: 10_000_000, // actual ~31,641 (110,653 for 2) -- https://goerli.etherscan.io/tx/0xcf717512796868273ed93c37fa139973c9b8305a736c4a3b50ac9f35ae747f99
+							Refund:    10_000_000, // actual ~59,152 -- https://goerli.etherscan.io/tx/0xc5692ad0e6d86b721af75ff3b4b7c2e17d939918db030ebf5444ccf840c7a90b
+							Approve:   5_000_000,  // actual ~3,455,202 (initial) -- https://goerli.arbiscan.io/tx/0xeb0c8204c3ebe6fa9301018b49e8b52dc4b18da6cde4ebd3d09083101206bf6c
+							Transfer:  10_000_000, // actual ~65,524 (initial receive, subsequent 48,424)
 						},
 					},
 				},


### PR DESCRIPTION
This is a working proof of concept on `testnet`, with these changes USDC/ETH & DCR trades between Arbitrum<->Decred settle just fine. Arbitrum wallet send/receive functionality seems to be operating correctly too.

`testnet` smart-contracts this PR references are exact copies of those used for  Ethereum, [here is how I managed to deploy these](https://github.com/norwnd/dcrdex/pull/21):
- https://goerli.arbiscan.io/address/0x37e27f6553f9c45e736c60939f96834ea0006be1
- https://goerli.arbiscan.io/address/0xdea876D65945ea9D7Cf4213be307EED2e469e27F

Next steps to take:
- figure out how best to reuse existing Ethereum implementation (with minimum copy-paste, yet such that logs/notifications/... aren't referencing Ethereum blockchain when Arbitrum was meant there)
- figure out whether we need `simnet` for Arbitrum, add it just for testing purposes ?
- test out all the edge-cases related to gas consumption and find out the best way to incorporate necessary changes into existing Ethereum code
- write/update some Arbitrum-specific docs (e.g. how to configure providers)
- deploy mainnet swap contracts to Arbitrum